### PR TITLE
Rewrote Curiosity contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,15 @@ The airdrop is insecure again; that was done on purpose.
 An airdrop can be claimed by anyone, but it won't be left like that for long.
 The contract will be fixed before the official launch.
 
-## `./webstie`
+## `webstie`
 ## Curiosity DAO Website/Airdrop Interface
 
 For CC readers/community members, they'll need an interface to claim their token airdrops.
-I'm going to build a website (preferably with help from better web devs) to do this.
+The website is in the process of being built, but is far from done.
 
-### Note
+You can look at Issue #1 on the [Curiosity-DAO page](https://github.com/Curiosity-DAO/Curiosity-DAO/issues/1) for more info.
 
-I don't actually have any idea of what I'm going to do yet, but I'll be working on it!
-
-## `./token_contracts`
+## `token_contracts`
 ## Curiosity DAO Token (CC)
 
 This is the set of contracts needed for the deployment of the CC governance token for the Curiosity DAO.
@@ -35,11 +33,11 @@ Links to specific contracts:
 - [IERC20](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/IERC20.sol)
 - [IERC20Metadata](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/extensions/IERC20Metadata.sol)
 - [ERC20](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol)
-- [ERC20Capped](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/extensions/ERC20Capped.sol)
 
 ### Note
 
 Curiosity isn't finished yet. At the moment, I plan to release everything 1st January 2022, but that can change anytime.
-I'm a single developer who is also working to publish a newsletter every week and trying to build a community around it.
-If you would like to help out with anything (please do), please reach out to me on Twitter [@theLucasWalters](https://twitter.com/theLucasWalters).
-My DM's are always open :)
+There are a total of 3 developers working on this repository at the moment, but we could always use more.
+If you would like to help out with anything (please do), please reach out to me on Twitter [@theLucasWalters](https://twitter.com/theLucasWalters) or in our Discord server ([here](https://discord.gg/Xs293sZAkW/)).
+
+If you contribute to the code in a meaningful way before the token airdrop, you'll be included on the whitelist.

--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ There are a total of 3 developers working on this repository at the moment, but 
 If you would like to help out with anything (please do), please reach out to me on Twitter [@theLucasWalters](https://twitter.com/theLucasWalters) or in our Discord server ([here](https://discord.gg/Xs293sZAkW/)).
 
 If you contribute to the code in a meaningful way before the token airdrop, you'll be included on the whitelist.
+You can also subscribe to the CryptoCurious newsletter on [Substack](https://lucaswalters.substack.com/) to claim an airdrop without doing any work if you so choose.

--- a/token_contracts/curiosity.sol
+++ b/token_contracts/curiosity.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.10;
 
 /**
- * @dev For details, read the README.md file in the Github repo @ https://github.com/theLucasWalters/Curiosity-DAO/blob/main/README.md
+ * @dev For details, read the README.md file in the Github repo @ https://github.com/Curiosity-DAO/Curiosity-DAO/blob/main/README.md
  */
 
 // Setup
@@ -23,7 +23,7 @@ uint constant remainder = initialSupply - dropSupply; // 3.5 million
 uint8 constant drops = 30; // current number of CC readers
 
 // size of each drop
-uint constant dropSize = dropSupply / drops; // 50,000 token per reader
+uint constant dropSize = dropSupply / drops; // 50,000 tokens per reader
 
 /**
  * @title Curiosity

--- a/token_contracts/setup.sol
+++ b/token_contracts/setup.sol
@@ -539,34 +539,3 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
         uint256 amount
     ) internal virtual {}
 }
-
-/**
- * @dev Extension of {ERC20} that adds a cap to the supply of tokens.
- */
-abstract contract ERC20Capped is ERC20 {
-    uint256 private immutable _cap;
-
-    /**
-     * @dev Sets the value of the `cap`. This value is immutable, it can only be
-     * set once during construction.
-     */
-    constructor(uint256 cap_) {
-        require(cap_ > 0, "ERC20Capped: cap is 0");
-        _cap = cap_;
-    }
-
-    /**
-     * @dev Returns the cap on the token's total supply.
-     */
-    function cap() public view virtual returns (uint256) {
-        return _cap;
-    }
-
-    /**
-     * @dev See {ERC20-_mint}.
-     */
-    function _mint(address account, uint256 amount) internal virtual override {
-        require(ERC20.totalSupply() + amount <= cap(), "ERC20Capped: cap exceeded");
-        super._mint(account, amount);
-    }
-}


### PR DESCRIPTION
I removed ERC20Capped from `setup.sol` and changed the Curiosity contract's inheritance to ERC20 & Ownable instead of ERC20Capped & Ownable. I also changed the initial supply of tokens to 5,000,000 (5 million) with 30 total drops for 50,000 tokens each. That brings the total drop supply to 1.5 million. The remaining 3.5 million will be sent to the DAO.

The previous numbers were a 100 million hard cap, 400,000 tokens per drop, and 25 total drops (CryptoCurious has grown).

Other changes are to adjust the contract to fit the removal of the hard cap, update the README with more current information, and fix typos.